### PR TITLE
Support go heapdumps from 1.7+

### DIFF
--- a/dumptodot/main.go
+++ b/dumptodot/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/randall77/hprof/read"
 )
 
@@ -80,7 +81,7 @@ func main() {
 		if !reachable[x] {
 			fmt.Printf("  v%d [style=filled fillcolor=gray];\n", x)
 		}
-		fmt.Printf("  v%d [label=\"%s\\n%d\"];\n", x, d.Ft(x).Name, d.Size(x))
+		fmt.Printf("  v%d [label=\"\\n%d\"];\n", x, d.Size(x))
 		for _, e := range d.Edges(x) {
 			var taillabel, headlabel string
 			if e.FieldName != "" {


### PR DESCRIPTION
Update the reader to support the newest heapdump format, based on https://github.com/golang/go/wiki/heapdump15-through-heapdump17

Trying to figure out how to get the type information of objects.